### PR TITLE
Bugfix: double images being recorded

### DIFF
--- a/urmoco/backend/dfmoco.py
+++ b/urmoco/backend/dfmoco.py
@@ -1,7 +1,10 @@
 def handle_dfmoco_request(dfmoco_req, state, robot, dfmoco_out_queue, urmoco_out_queue):
     if dfmoco_req["type"] == "move_to_frame":
-        state["move"]["scheduled"] = True
-        urmoco_out_queue.put(dfmoco_req)
+        if state["move"]["scheduled"]:
+            return
+        else:
+            state["move"]["scheduled"] = True
+            urmoco_out_queue.put(dfmoco_req)
 
     if dfmoco_req["type"] == "is_moving":
         dfmoco_out_queue.put(

--- a/urmoco/backend/dfmoco.py
+++ b/urmoco/backend/dfmoco.py
@@ -1,11 +1,16 @@
 def handle_dfmoco_request(dfmoco_req, state, robot, dfmoco_out_queue, urmoco_out_queue):
     if dfmoco_req["type"] == "move_to_frame":
+        state["move"]["scheduled"] = True
         urmoco_out_queue.put(dfmoco_req)
-        dfmoco_out_queue.put(dfmoco_req)
 
     if dfmoco_req["type"] == "is_moving":
         dfmoco_out_queue.put(
-            {"type": "is_moving", "payload": {"is_moving": state["move"]["active"]}}
+            {
+                "type": "is_moving",
+                "payload": {
+                    "is_moving": state["move"]["active"] or state["move"]["scheduled"]
+                },
+            }
         )
 
     if dfmoco_req["type"] in {"stop_motor", "stop_all"}:

--- a/urmoco/backend/move.py
+++ b/urmoco/backend/move.py
@@ -14,6 +14,8 @@ def handle_move(config, state, robot: RobotClient, ur_out_q, df_out_q):
             logger.debug("Robot not steady yet")
         else:
             logger.debug("Steady at target")
+            state["move"]["stopping"] = False
+            state["move"]["scheduled"] = False
             state["move"]["active"] = False
             state["move"]["target_joints"] = None
             state["move"]["time_elapsed_seconds"] = 0
@@ -30,6 +32,7 @@ def handle_move(config, state, robot: RobotClient, ur_out_q, df_out_q):
         else:
             state["frame"] = -1
             state["move"]["stopping"] = False
+            state["move"]["scheduled"] = False
             state["move"]["active"] = False
             state["move"]["target_joints"] = None
             state["move"]["time_elapsed_seconds"] = 0

--- a/urmoco/backend/state.py
+++ b/urmoco/backend/state.py
@@ -8,6 +8,7 @@ initial_state = {
     "robot_mode": None,
     "safety_mode": None,
     "move": {
+        "scheduled": False,
         "active": False,
         "stopping": False,
         "target_joints": None,

--- a/urmoco/backend/urmoco.py
+++ b/urmoco/backend/urmoco.py
@@ -68,6 +68,12 @@ def handle_urmoco_request(
             state["move"]["target_joints"] = target_joints
             if "target_frame" in urmoco_req["payload"].keys():
                 state["move"]["target_frame"] = urmoco_req["payload"]["target_frame"]
+                dfmoco_out_queue.put(
+                    {
+                        "type": "move_to_frame",
+                        "payload": {"target_frame": state["move"]["target_frame"]},
+                    }
+                )
             if not state["shooting"]:
                 state["frame"] = -1
                 dfmoco_out_queue.put(

--- a/urmoco/config.py
+++ b/urmoco/config.py
@@ -7,11 +7,6 @@ from xdg import XDG_CONFIG_HOME
 logger = logging.getLogger(__name__)
 
 defaults = {
-    "dfmoco": {
-        "host": "localhost",
-        "port": 25555,
-        "producer_interval_seconds": 1,
-    },
     "robot": {
         "host": "192.168.5.42",
         "payload": 1,

--- a/urmoco/dfmoco/consumer.py
+++ b/urmoco/dfmoco/consumer.py
@@ -52,7 +52,7 @@ request_handlers = {
 }
 
 
-async def run(_config, in_queue, reader):
+async def run(in_queue, reader):
     while True:
         request = await reader.readuntil(separator=b"\r\n")
 

--- a/urmoco/dfmoco/proc.py
+++ b/urmoco/dfmoco/proc.py
@@ -1,12 +1,13 @@
 import asyncio
 import logging
+from multiprocessing import Queue
 
 from .server import create_dfmoco_server
 
 logger = logging.getLogger(__name__)
 
 
-async def run_dfmoco_server(dfmoco_in_queue, dfmoco_out_queue):
+async def run_dfmoco_server(dfmoco_in_queue: Queue, dfmoco_out_queue: Queue):
     dfmoco_server = await create_dfmoco_server(dfmoco_in_queue, dfmoco_out_queue)
 
     addr = dfmoco_server.sockets[0].getsockname()

--- a/urmoco/dfmoco/proc.py
+++ b/urmoco/dfmoco/proc.py
@@ -1,15 +1,13 @@
 import asyncio
 import logging
 
-from .server import DFMocoServer
+from .server import create_dfmoco_server
 
 logger = logging.getLogger(__name__)
 
 
-async def run_dfmoco_server(config, dfmoco_in_queue, dfmoco_out_queue):
-    dfmoco_server = await DFMocoServer(
-        config, dfmoco_in_queue, dfmoco_out_queue
-    ).start()
+async def run_dfmoco_server(dfmoco_in_queue, dfmoco_out_queue):
+    dfmoco_server = await create_dfmoco_server(dfmoco_in_queue, dfmoco_out_queue)
 
     addr = dfmoco_server.sockets[0].getsockname()
     logger.info(f"DFMoco server started on {addr[0]}:{addr[1]}")
@@ -17,5 +15,5 @@ async def run_dfmoco_server(config, dfmoco_in_queue, dfmoco_out_queue):
     await dfmoco_server.serve_forever()
 
 
-def run(config, dfmoco_in_queue, dfmoco_out_queue):
-    asyncio.run(run_dfmoco_server(config, dfmoco_in_queue, dfmoco_out_queue))
+def run(dfmoco_in_queue, dfmoco_out_queue):
+    asyncio.run(run_dfmoco_server(dfmoco_in_queue, dfmoco_out_queue))

--- a/urmoco/dfmoco/producer.py
+++ b/urmoco/dfmoco/producer.py
@@ -1,53 +1,65 @@
 import asyncio
 import logging
 import queue
+from asyncio import StreamWriter
+from multiprocessing import Queue
+
+from urmoco.config import Config
+from urmoco.dfmoco.state import DFMocoState
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
 
-async def stop_all(state, _response_payload, writer):
-    state["is_moving"] = False
-    response = f"sa\r\n"
-    writer.write(bytes(response, encoding="ascii"))
+async def stop_all(state: DFMocoState, _response_payload, writer: StreamWriter):
+    state.is_moving = False
+    state.current_frame = -1
+    writer.write(b"sa\r\n")
     await writer.drain()
 
 
-async def stop_motor(state, _response_payload, writer):
-    state["is_moving"] = False
-    response = "sm 1\r\n"
-    writer.write(bytes(response, encoding="ascii"))
+async def stop_motor(state: DFMocoState, _response_payload, writer: StreamWriter):
+    state.is_moving = False
+    state.current_frame = -1
+    writer.write(b"sm 1\r\n")
     await writer.drain()
 
 
-async def set_frame(state, response_payload, writer):
-    state["current_frame"] = response_payload["current_frame"]
-    heartbeat_message = f"mp {1} {state['current_frame']}\r\n"
-    writer.write(bytes(heartbeat_message, encoding="ascii"))
+async def set_frame(state: DFMocoState, response_payload, writer: StreamWriter):
+    state.current_frame = response_payload["current_frame"]
+    message = f"mp 1 {state.current_frame}\r\n"
+    writer.write(bytes(message, encoding="ascii"))
     await writer.drain()
 
 
-async def move_to_frame(state, response_payload, writer):
-    state["is_moving"] = True
+async def move_to_frame(state: DFMocoState, response_payload, writer: StreamWriter):
+    state.is_moving = True
+    state.current_frame = -1
     response = f'mm 1 {response_payload["target_frame"]}\r\n'
     writer.write(bytes(response, encoding="ascii"))
     await writer.drain()
 
 
-async def is_moving(state, response_payload, writer):
-    state["is_moving"] = response_payload["is_moving"]
+async def is_moving(state: DFMocoState, response_payload, writer: StreamWriter):
+    state.is_moving = response_payload["is_moving"]
+    if state.is_moving:
+        state.current_frame = -1
 
-    response = f'ms {1 if state["is_moving"] else 0}\r\n'
+    response = f"ms {1 if state.is_moving else 0}\r\n"
     writer.write(bytes(response, encoding="ascii"))
     await writer.drain()
 
 
-async def handle_move_timeout(state, _response_payload, writer):
+async def handle_move_timeout(
+    state: DFMocoState, _response_payload, writer: StreamWriter
+):
     await is_moving(state, {"is_moving": False}, writer)
     await set_frame(state, {"current_frame": -1}, writer)
 
 
-async def handle_move_success(state, response_payload, writer):
+async def handle_move_success(
+    state: DFMocoState, response_payload, writer: StreamWriter
+):
     await is_moving(state, {"is_moving": False}, writer)
     await set_frame(state, {"current_frame": response_payload["frame"]}, writer)
 
@@ -63,24 +75,34 @@ response_handlers = {
 }
 
 
-async def run(config, state, out_queue, writer):
-    while True:
-        try:
-            response = out_queue.get_nowait()
-            response_type = response["type"]
-            response_payload = response.get("payload", False) or {}
+async def run_cycle(
+    config: Config, state: DFMocoState, out_queue: Queue, writer: StreamWriter
+):
+    try:
+        response = out_queue.get_nowait()
+        response_type = response["type"]
+        response_payload = response.get("payload", False) or {}
 
-            handler = response_handlers.get(response_type)
-            if handler is None:
-                logger.error(
-                    "No handler for response type %s. Ignoring.", response_type
-                )
-                continue
+        handler = response_handlers.get(response_type)
+        if handler is None:
+            raise NotImplementedError("No handler for response type %s.", response_type)
 
-            await handler(state, response_payload, writer)
+        await handler(state, response_payload, writer)
 
-        except queue.Empty:
-            heartbeat_message = f"mp {1} {state['current_frame']}\r\n"
+    except queue.Empty:
+        if state.is_moving:
+            heartbeat_message = f"ms 1\r\n"
             writer.write(bytes(heartbeat_message, encoding="ascii"))
             await writer.drain()
-            await asyncio.sleep(config.get("dfmoco.producer_interval_seconds"))
+        else:
+            heartbeat_message = f"mp 1 {state.current_frame}\r\n"
+            writer.write(bytes(heartbeat_message, encoding="ascii"))
+            await writer.drain()
+        await asyncio.sleep(config.get("dfmoco.producer_interval_seconds"))
+
+
+async def run(
+    config: Config, state: DFMocoState, out_queue: Queue, writer: StreamWriter
+):
+    while True:
+        await run_cycle(config, state, out_queue, writer)

--- a/urmoco/dfmoco/server.py
+++ b/urmoco/dfmoco/server.py
@@ -4,8 +4,6 @@ import queue
 from asyncio import StreamReader, StreamWriter
 from multiprocessing import Queue
 
-from urmoco.config import Config
-
 from . import consumer, producer
 from .state import DFMocoState
 
@@ -13,16 +11,48 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
+def clear_queue(q: Queue):
+    while True:
+        try:
+            q.get_nowait()
+        except queue.Empty:
+            break
+
+
+def get_connection_handler(in_queue, out_queue):
+    async def handle_connection(reader: StreamReader, writer: StreamWriter):
+        logger.info("Connected to Dragonframe")
+
+        clear_queue(in_queue)
+        clear_queue(out_queue)
+
+        state: DFMocoState = DFMocoState(current_frame=-1, is_moving=False)
+
+        writer.write(bytes("hi 1 1 1.2.5\r\n", "ascii"))
+        writer.write(bytes("mp 1 -1\r\n", "ascii"))
+        await writer.drain()
+
+        consumer_task = asyncio.create_task(consumer.run(in_queue, reader))
+        producer_task = asyncio.create_task(producer.run(state, out_queue, writer))
+
+        e = await asyncio.gather(consumer_task, producer_task, return_exceptions=True)
+        logger.error(f"Disconnected from Dragonframe, an error occurred: {e}")
+
+    return handle_connection
+
+
+async def create_dfmoco_server(in_queue, out_queue):
+    connection_handler = get_connection_handler(in_queue, out_queue)
+    return await asyncio.start_server(connection_handler, "localhost", 25555)
+
+
 class DFMocoServer:
-    def __init__(self, config: Config, dfmoco_in_queue: Queue, dfmoco_out_queue: Queue):
-        self.config = config
+    def __init__(self, dfmoco_in_queue: Queue, dfmoco_out_queue: Queue):
         self.in_queue = dfmoco_in_queue
         self.out_queue = dfmoco_out_queue
 
     async def start(self):
-        host = self.config.get("dfmoco.host")
-        port = self.config.get("dfmoco.port")
-        return await asyncio.start_server(self.handle_connection, host, port)
+        return await asyncio.start_server(self.handle_connection, "0.0.0.0", 25555)
 
     async def handle_connection(self, reader: StreamReader, writer: StreamWriter):
         logger.info("Connected to Dragonframe")
@@ -45,12 +75,8 @@ class DFMocoServer:
         writer.write(bytes("hi 1 1 1.2.5\r\n", "ascii"))
         await writer.drain()
 
-        consumer_task = asyncio.create_task(
-            consumer.run(self.config, self.in_queue, reader)
-        )
-        producer_task = asyncio.create_task(
-            producer.run(self.config, state, self.out_queue, writer)
-        )
+        consumer_task = asyncio.create_task(consumer.run(self.in_queue, reader))
+        producer_task = asyncio.create_task(producer.run(state, self.out_queue, writer))
 
         e = await asyncio.gather(consumer_task, producer_task, return_exceptions=True)
         logger.error(f"Disconnected from Dragonframe, an error occurred: {e}")

--- a/urmoco/dfmoco/server.py
+++ b/urmoco/dfmoco/server.py
@@ -19,7 +19,7 @@ def clear_queue(q: Queue):
             break
 
 
-def get_connection_handler(in_queue, out_queue):
+def get_connection_handler(in_queue: Queue, out_queue: Queue):
     async def handle_connection(reader: StreamReader, writer: StreamWriter):
         logger.info("Connected to Dragonframe")
 
@@ -41,42 +41,6 @@ def get_connection_handler(in_queue, out_queue):
     return handle_connection
 
 
-async def create_dfmoco_server(in_queue, out_queue):
+async def create_dfmoco_server(in_queue: Queue, out_queue: Queue):
     connection_handler = get_connection_handler(in_queue, out_queue)
     return await asyncio.start_server(connection_handler, "localhost", 25555)
-
-
-class DFMocoServer:
-    def __init__(self, dfmoco_in_queue: Queue, dfmoco_out_queue: Queue):
-        self.in_queue = dfmoco_in_queue
-        self.out_queue = dfmoco_out_queue
-
-    async def start(self):
-        return await asyncio.start_server(self.handle_connection, "0.0.0.0", 25555)
-
-    async def handle_connection(self, reader: StreamReader, writer: StreamWriter):
-        logger.info("Connected to Dragonframe")
-
-        # Clear queues
-        while True:
-            try:
-                self.in_queue.get_nowait()
-            except queue.Empty:
-                break
-
-        while True:
-            try:
-                self.out_queue.get_nowait()
-            except queue.Empty:
-                break
-
-        state: DFMocoState = DFMocoState(current_frame=-1, is_moving=False)
-
-        writer.write(bytes("hi 1 1 1.2.5\r\n", "ascii"))
-        await writer.drain()
-
-        consumer_task = asyncio.create_task(consumer.run(self.in_queue, reader))
-        producer_task = asyncio.create_task(producer.run(state, self.out_queue, writer))
-
-        e = await asyncio.gather(consumer_task, producer_task, return_exceptions=True)
-        logger.error(f"Disconnected from Dragonframe, an error occurred: {e}")

--- a/urmoco/dfmoco/state.py
+++ b/urmoco/dfmoco/state.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class DFMocoState:
+    is_moving: bool
+    current_frame: int

--- a/urmoco/dfmoco/test_producer.py
+++ b/urmoco/dfmoco/test_producer.py
@@ -1,0 +1,204 @@
+import queue
+from asyncio import StreamWriter
+from multiprocessing import Queue
+from unittest.mock import AsyncMock, Mock, call
+
+import pytest
+
+from urmoco.config import Config
+from urmoco.dfmoco import producer
+from urmoco.dfmoco.state import DFMocoState
+
+
+@pytest.fixture
+def config() -> Config:
+    return Mock()
+
+
+@pytest.fixture
+def out_queue() -> Queue:
+    return Mock()
+
+
+@pytest.fixture
+def writer() -> StreamWriter:
+    writer = Mock()
+    writer.drain = AsyncMock()
+    return writer
+
+
+@pytest.mark.asyncio
+async def test_send_motor_position_heartbeat(config, out_queue, writer):
+    # Arrange
+    state = DFMocoState(current_frame=42, is_moving=False)
+    config.get.return_value = 12
+    out_queue.get_nowait.side_effect = queue.Empty()
+
+    # Act
+    await producer.run_cycle(config, state, out_queue, writer)
+
+    # Assert
+    writer.write.assert_called_once_with(b"mp 1 42\r\n")
+    writer.drain.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_motor_status_heartbeat(config, out_queue, writer):
+    # Arrange
+    state = DFMocoState(current_frame=-1, is_moving=True)
+    config.get.return_value = 12
+    out_queue.get_nowait.side_effect = queue.Empty()
+
+    # Act
+    await producer.run_cycle(config, state, out_queue, writer)
+
+    # Assert
+    writer.write.assert_called_once_with(b"ms 1\r\n")
+    writer.drain.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_unknown_message(config, out_queue, writer):
+    # Arrange
+    out_queue.get_nowait.return_value = {"type": "blablabla"}
+
+    # Act & assert
+    with pytest.raises(NotImplementedError):
+        await producer.run(
+            config, {"is_moving": False, "current_frame": -1}, out_queue, writer
+        )
+
+
+@pytest.mark.asyncio
+async def test_stop_all(writer):
+    # Arrange
+    state = DFMocoState(current_frame=42, is_moving=True)
+
+    # Act
+    await producer.stop_all(state, None, writer)
+
+    # Assert
+    writer.write.assert_called_once_with(b"sa\r\n")
+    writer.drain.assert_called_once()
+    assert not state.is_moving
+    assert state.current_frame == -1
+
+
+@pytest.mark.asyncio
+async def test_stop_motor(writer):
+    # Arrange
+    state = DFMocoState(current_frame=24, is_moving=True)
+
+    # Act
+    await producer.stop_motor(state, None, writer)
+
+    # Assert
+    writer.write.assert_called_once_with(b"sm 1\r\n")
+    writer.drain.assert_called_once()
+    assert not state.is_moving
+    assert state.current_frame == -1
+
+
+@pytest.mark.asyncio
+async def test_set_frame(writer):
+    # Arrange
+    state = DFMocoState(current_frame=24, is_moving=True)
+
+    # Act
+    await producer.set_frame(state, {"current_frame": 42}, writer)
+
+    # Assert
+    writer.write.assert_called_once_with(b"mp 1 42\r\n")
+    writer.drain.assert_called_once()
+    assert state.is_moving
+    assert state.current_frame == 42
+
+
+@pytest.mark.asyncio
+async def test_move_to_frame(writer):
+    # Arrange
+    state = DFMocoState(current_frame=1, is_moving=False)
+
+    # Act
+    await producer.move_to_frame(state, {"target_frame": 42}, writer)
+
+    # Assert
+    writer.write.assert_called_once_with(b"mm 1 42\r\n")
+    writer.drain.assert_called_once()
+    assert state.is_moving
+    assert state.current_frame == -1
+
+
+@pytest.mark.asyncio
+async def test_is_moving_starting(writer):
+    # Arrange
+    state = DFMocoState(current_frame=12, is_moving=False)
+
+    # Act
+    await producer.is_moving(state, {"is_moving": True}, writer)
+
+    # Assert
+    writer.write.assert_called_once_with(b"ms 1\r\n")
+    writer.drain.assert_called_once()
+    assert state.is_moving
+    assert state.current_frame == -1
+
+
+@pytest.mark.asyncio
+async def test_is_moving_stopping(writer):
+    # Arrange
+    state = DFMocoState(current_frame=-1, is_moving=True)
+
+    # Act
+    await producer.is_moving(state, {"is_moving": False}, writer)
+
+    # Assert
+    writer.write.assert_called_once_with(b"ms 0\r\n")
+    writer.drain.assert_called_once()
+    assert not state.is_moving
+    assert state.current_frame == -1
+
+
+@pytest.mark.asyncio
+async def test_is_moving_already_stopped(writer):
+    # Arrange
+    state = DFMocoState(current_frame=12, is_moving=False)
+
+    # Act
+    await producer.is_moving(state, {"is_moving": False}, writer)
+
+    # Assert
+    writer.write.assert_called_once_with(b"ms 0\r\n")
+    writer.drain.assert_called_once()
+    assert not state.is_moving
+    assert state.current_frame == 12
+
+
+@pytest.mark.asyncio
+async def test_handle_move_timeout(writer):
+    # Arrange
+    state = DFMocoState(current_frame=12, is_moving=True)
+
+    # Act
+    await producer.handle_move_timeout(state, None, writer)
+
+    # Assert
+    writer.write.assert_has_calls([call(b"ms 0\r\n"), call(b"mp 1 -1\r\n")])
+    writer.drain.assert_called()
+    assert not state.is_moving
+    assert state.current_frame == -1
+
+
+@pytest.mark.asyncio
+async def test_handle_move_success(writer):
+    # Arrange
+    state = DFMocoState(current_frame=-1, is_moving=True)
+
+    # Act
+    await producer.handle_move_success(state, {"frame": 42}, writer)
+
+    # Assert
+    writer.write.assert_has_calls([call(b"ms 0\r\n"), call(b"mp 1 42\r\n")])
+    writer.drain.assert_called()
+    assert not state.is_moving
+    assert state.current_frame == 42

--- a/urmoco/dfmoco/test_server.py
+++ b/urmoco/dfmoco/test_server.py
@@ -1,0 +1,71 @@
+from asyncio import StreamWriter
+from multiprocessing import Queue
+from unittest.mock import AsyncMock, Mock, call
+
+import pytest
+
+
+@pytest.fixture
+def out_queue() -> Queue:
+    return Mock()
+
+
+@pytest.fixture
+def in_queue() -> Queue:
+    return Mock()
+
+
+@pytest.fixture
+def writer() -> StreamWriter:
+    writer = Mock()
+    writer.drain = AsyncMock()
+    return writer
+
+
+@pytest.fixture
+def reader() -> StreamWriter:
+    writer = Mock()
+    writer.drain = AsyncMock()
+    return writer
+
+
+def test_clear_queue():
+    # Arrange
+    q = Queue()
+    q.put({"type": "some_message"})
+    q.put({"type": "some_other_message"})
+    q.put({"type": "some_some_message"})
+
+    from urmoco.dfmoco import server
+
+    # Act
+    server.clear_queue(q)
+
+    # Assert
+    assert q.empty()
+
+
+@pytest.mark.asyncio
+async def test_clear_queues_on_new_session(mocker, in_queue, out_queue, reader, writer):
+    # Arrange
+    create_task = mocker.patch("asyncio.create_task")
+    gather = mocker.patch("asyncio.gather", new_callable=AsyncMock)
+
+    from urmoco.dfmoco import server
+
+    connection_handler = server.get_connection_handler(in_queue, out_queue)
+    server.clear_queue = Mock()
+
+    # Act
+    await connection_handler(reader, writer)
+
+    # Assert
+    server.clear_queue.assert_has_calls(
+        [call(in_queue), call(out_queue)], any_order=True
+    )
+
+    writer.write.assert_has_calls([call(b"hi 1 1 1.2.5\r\n"), call(b"mp 1 -1\r\n")])
+    writer.drain.assert_called_once()
+
+    create_task.assert_called()
+    gather.assert_called_once()

--- a/urmoco/scheduler.py
+++ b/urmoco/scheduler.py
@@ -27,7 +27,7 @@ class Scheduler:
             self.df_server_proc = self.ctx.Process(
                 target=run_df,
                 name="DFMoco server",
-                args=(config, self.df_in_q, self.df_out_q),
+                args=(self.df_in_q, self.df_out_q),
                 daemon=True,
             )
             self.df_server_proc.start()

--- a/urmoco/test_config.py
+++ b/urmoco/test_config.py
@@ -11,8 +11,8 @@ def test_given_value():
 
 def test_hard_coded_value():
     config = Config({})
-    dfmoco_port = config.get("dfmoco.port")
-    assert dfmoco_port == 25555
+    robot_host = config.get("robot.host")
+    assert robot_host == "192.168.5.42"
 
 
 def test_array_without_string_name():

--- a/urmoco/test_it_dfmoco.py
+++ b/urmoco/test_it_dfmoco.py
@@ -35,11 +35,11 @@ class DFMocoProcess:
             daemon=True,
         )
         self.dfmoco_proc.start()
-        time.sleep(1)
+        time.sleep(.1)
 
     def stop(self):
         self.dfmoco_proc.kill()
-        time.sleep(1)
+        time.sleep(.1)
 
 
 @pytest.fixture
@@ -88,7 +88,7 @@ class DFMocoClient:
         self.dfmoco_server.stop()
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(1)
 def test_receive_hi(dfmoco_client):
     dfmoco_client.connect()
     dfmoco_client.send("hi\r\n")
@@ -96,7 +96,7 @@ def test_receive_hi(dfmoco_client):
     dfmoco_client.stop()
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(1)
 def test_receive_heartbeat(dfmoco_client):
     dfmoco_client.connect()
     assert dfmoco_client.readline_raw() == "hi 1 1 1.2.5\n"
@@ -104,7 +104,7 @@ def test_receive_heartbeat(dfmoco_client):
     dfmoco_client.stop()
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(2)
 def test_is_not_moving(dfmoco_client):
     dfmoco_client.connect()
     dfmoco_client.send("ms\r\n")
@@ -115,7 +115,7 @@ def test_is_not_moving(dfmoco_client):
     dfmoco_client.stop()
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(2)
 def test_is_moving(dfmoco_client):
     dfmoco_client.connect()
     dfmoco_client.send("ms\r\n")
@@ -127,7 +127,7 @@ def test_is_moving(dfmoco_client):
     dfmoco_client.stop()
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(2)
 def test_stop_motor(dfmoco_client):
     dfmoco_client.connect()
     dfmoco_client.send("sm 1\r\n")
@@ -138,7 +138,7 @@ def test_stop_motor(dfmoco_client):
     dfmoco_client.stop()
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(2)
 def test_stop_all(dfmoco_client):
     dfmoco_client.connect()
     dfmoco_client.send("sa\r\n")
@@ -149,7 +149,7 @@ def test_stop_all(dfmoco_client):
     dfmoco_client.stop()
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(10)
 def test_move_to_frame(dfmoco_client):
     dfmoco_client.connect()
 


### PR DESCRIPTION
This should resolve an issue where the motor position was tracked not correctly. This has led to duplicate images. When Dragonframe executes multiple captures in a row and it gets delivered a motor not moving message, it skips a frame, which leads to duplicate images. This change mitigates this issue for now. The issue still persists, when Blender is not active and the busy loop running in the Blender process gets stalled. This will need to be adressed in the future.